### PR TITLE
DEV-2219: upgrade reactive-papi

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ df
 
 ## Platform WebSocket API
 
-The websocket feed provides real-time level 2 market data snapshots and public trades via
+The websocket feed provides real-time level 2 market data snapshots, public trades and liquidation
+via
 
 ```
 wss://api.platform.reactivemarkets.com/feed

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 flatbuffers>=1.12
-reactive-papi==0.7.0
+reactive-papi==1.2.0
 pytz==2020.1
 requests==2.23.0
 urllib3>=1.25.2,<1.26

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ platforms = any
 [options]
 python_requires = >=3.7
 install_requires =
-    reactive-papi==0.7.0
+    reactive-papi==1.2.0
     flatbuffers>=1.12
     pytz==2020.1
     requests==2.23.0
@@ -48,7 +48,7 @@ package_dir =
 
 [options.extras_require]
 testing =
-    reactive-papi==0.7.0
+    reactive-papi==1.2.0
     pytest
     pytest-cov
     flake8

--- a/src/reactive/platform/feed/client.py
+++ b/src/reactive/platform/feed/client.py
@@ -59,7 +59,7 @@ class FeedClient(Client):
                         freq: int = 1):
         """
         subscribe sends a subscription FeedRequest to reactive platform, the default request is
-        a marketdata request.
+        a market data request.
 
         Parameters
         ----------
@@ -75,7 +75,7 @@ class FeedClient(Client):
           subscribe marketdata l2 orderbook grouping ticks per level, if feed_type is Default,
           otherwise the field is ignored.
         freq: int, default 1
-          required marketdata update frequency, if feed_type is Default.
+          required market data update frequency, if feed_type is Default.
           otherwise the field is ignored by the platform.
         """
         self.req_id += 1

--- a/src/reactive/platform/feed/decode.py
+++ b/src/reactive/platform/feed/decode.py
@@ -20,6 +20,7 @@ from reactive.papi.Message import Message
 
 from reactive.platform.feed.feedaccept import FeedRequestAccept
 from reactive.platform.feed.feedrequestreject import FeedRequestReject
+from reactive.platform.feed.liquidation import LiquidationOrder
 from reactive.platform.feed.mdsnapshotl2 import MDSnapshotL2
 from reactive.platform.feed.publictrade import PublicTrade
 
@@ -41,3 +42,5 @@ def load_from_fbs(msg: Message) -> Union[MDSnapshotL2, FeedRequestAccept,
         return MDSnapshotL2.load_from_fbs(body)
     elif body_type == Body.PublicTrade:
         return PublicTrade.load_from_fbs(body)
+    elif body_type == Body.LiquidationOrder:
+        return LiquidationOrder.load_from_fbs(body)

--- a/src/reactive/platform/feed/feedrequest.py
+++ b/src/reactive/platform/feed/feedrequest.py
@@ -35,6 +35,29 @@ class FeedRequest:
                  grouping: int = 1,
                  sub_req_type: int = FbsSrt.SubReqType.Subscribe,
                  freq: int = 1):
+        """
+        Parameters
+        ----------
+        req_id : str
+          Feed request from client, should be echo back in FeedAccept message.
+        markets : List[str]
+          list of markets to subscribe.
+        feed_type : int
+          FeedType : 0 (Default for market data)
+                     1 (Trade)
+                     2 (Liquidation)
+        depth : int
+          order book depth, if feed_type is 0, otherwise, this field is ignored.
+        grouping : int
+          grouping in aggregate algo on order book, if feed_type is 0, otherwise, this
+          field is ignore.
+        sub_req_type : int
+           1: subscribe
+           2: unsubscribe
+        freq : int
+          book update frequency in milliseconds, if feed_type is 0, otherwise, this field is
+          ignored.
+        """
         self.req_id = req_id
         self.markets = markets
         self.sub_req_type = sub_req_type

--- a/src/reactive/platform/feed/liquidation.py
+++ b/src/reactive/platform/feed/liquidation.py
@@ -15,22 +15,23 @@
 """
 Summary
 -------
-Public trade data structures.
+Liquidation order data structures.
 
 """
 
-import reactive.papi.PublicTrade as FbsPt
+import reactive.papi.LiquidationOrder as FbsLo
 
 
-class PublicTrade:
+class LiquidationOrder:
 
     def __init__(self, market: str, side: int, qty: float, price: float,
-                 source_ts: int = 0, source: str = "", trade_id: str = "",
-                 flags: int = 0, exec_venue: str = ""):
+                 source_ts: int = 0, source: str = "", feed_id: int = 0,
+                 order_id: str = "", flags: int = 0, exec_venue: str = ""):
         self.source_ts = source_ts
         self.source = source
         self.market = market
-        self.trade_id = trade_id
+        self.feed_id = feed_id
+        self.order_id = order_id
         self.flags = flags
         self.side = side
         self.qty = qty
@@ -38,8 +39,9 @@ class PublicTrade:
         self.exec_venue = exec_venue
 
     @classmethod
-    def load_from_fbs(cls, trade: FbsPt.PublicTrade):
-        return cls(market=trade.Market(), side=trade.Side(), qty=trade.Qty(),
-                   price=trade.Qty(), source_ts=trade.SourceTs(), source=trade.Source(),
-                   trade_id=trade.TradeId(), flags=trade.Flags(),
-                   exec_venue=trade.ExecVenue())
+    def load_from_fbs(cls, liquidation: FbsLo.LiquidationOrder):
+        return cls(market=liquidation.Market(), side=liquidation.Side(), qty=liquidation.Qty(),
+                   price=liquidation.Qty(), source_ts=liquidation.SourceTs(),
+                   source=liquidation.Source(), feed_id=liquidation.FeedId(),
+                   order_id=liquidation.OrderId(), flags=liquidation.Flags(),
+                   exec_venue=liquidation.ExecVenue())

--- a/src/reactive/platform/websocket/decode.py
+++ b/src/reactive/platform/websocket/decode.py
@@ -19,6 +19,7 @@ from typing import Union, Tuple
 from reactive.papi.Body import Body
 from reactive.papi.FeedRequestAccept import FeedRequestAccept
 from reactive.papi.FeedRequestReject import FeedRequestReject
+from reactive.papi.LiquidationOrder import LiquidationOrder
 from reactive.papi.MDSnapshotL2 import MDSnapshotL2
 from reactive.papi.Message import Message
 from reactive.papi.PublicTrade import PublicTrade
@@ -26,8 +27,10 @@ from reactive.papi.PublicTrade import PublicTrade
 
 def decode_fbs(msg: Message) -> Tuple[Body, Union[MDSnapshotL2,
                                                   PublicTrade,
+                                                  LiquidationOrder,
                                                   FeedRequestReject,
-                                                  FeedRequestAccept]]:
+                                                  FeedRequestAccept,
+                                                  None]]:
     """
     Decode a reactive.papi.Message into the Msg BodyType and body object.
     """
@@ -47,5 +50,9 @@ def decode_fbs(msg: Message) -> Tuple[Body, Union[MDSnapshotL2,
         fra = FeedRequestAccept()
         fra.Init(msg.Body().Bytes, msg.Body().Pos)
         return Body.FeedRequestAccept, fra
+    elif msg.BodyType() == Body.LiquidationOrder:
+        lo = LiquidationOrder()
+        lo.Init(msg.Body().Bytes, msg.Body().Pos)
+        return Body.LiquidationOrder, lo
     else:
         return Body.NONE, None

--- a/src/reactive/platform/websocket/handler.py
+++ b/src/reactive/platform/websocket/handler.py
@@ -37,9 +37,13 @@ def print_data_handler(msg: Message):
         best_bid = None if bid_length == 0 else body.BidSide(0).Price()
         offer_length = body.OfferSideLength()
         best_offer = None if offer_length == 0 else body.OfferSide(0).Price()
-        print(market, best_bid, best_offer)
+        print("market data:", market, best_bid, best_offer)
     elif body_type == Body.PublicTrade:
-        print(body.Market(), body.ExecVenue(), body.Price(), body.Qty(), body.Side())
+        print("public trade:", body.Market(), body.ExecVenue(), body.Price(), body.Qty(),
+              body.Side())
+    elif body_type == Body.LiquidationOrder:
+        print("liquidation:", body.Market(), body.ExecVenue(), body.Price(), body.Qty(),
+              body.Side())
     elif body_type == Body.FeedRequestReject:
         print(f"feed request {body.ReqId()} is rejected: {body.ErrorCode()},"
               f"{body.ErrorMessage()}")

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ deps =
     flake8
     pytest>=3
     pytest-cov
-    reactive-papi==0.7.0
+    reactive-papi==1.2.0
+    numpy
 commands =
     flake8 src/ tests/
     pytest tests/


### PR DESCRIPTION
Stack upgrade reactive-papi to 1.2.0, and add support
to subscribe liquidation orders.

DEV-2219